### PR TITLE
fix(create-next-plugin-preval): stop error when using webpack second argument

### DIFF
--- a/src/create-next-plugin-preval.ts
+++ b/src/create-next-plugin-preval.ts
@@ -7,8 +7,16 @@ interface WebpackConfig {
   [key: string]: any;
 }
 
+interface WebpackOptions {
+  buildId: string;
+  dev: boolean;
+  isServer: boolean;
+  defaultLoaders: object;
+  babel: object;
+}
+
 interface NextConfigValue {
-  webpack?: (config: WebpackConfig) => WebpackConfig;
+  webpack?: (config: WebpackConfig, options: WebpackOptions) => WebpackConfig;
   [key: string]: any;
 }
 
@@ -24,8 +32,8 @@ function createNextPluginPreval(options: NextPluginPrevalOptions) {
 
       return {
         ...nextConfig,
-        webpack: (config: WebpackConfig) => {
-          const webpackConfig = nextConfig.webpack?.(config) || {};
+        webpack: (config: WebpackConfig, options: WebpackOptions) => {
+          const webpackConfig = nextConfig.webpack?.(config, options) || {};
 
           const rules = webpackConfig.module?.rules;
 


### PR DESCRIPTION
[`next.config.js` webpack config accepts two arguments](https://nextjs.org/docs/api-reference/next.config.js/custom-webpack-config).

When you use this second argument with `next-plugin-preval`, it throws an error.

This PR will fix it.