### PR TITLE
chore: allow next v11 in peerDependencies

### DIFF
--- a/examples/example-app/next.config.js
+++ b/examples/example-app/next.config.js
@@ -2,5 +2,7 @@ const createNextPluginPreval = require('next-plugin-preval/config');
 const withNextPluginPreval = createNextPluginPreval();
 
 module.exports = withNextPluginPreval({
-  future: { webpack5: true },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -7914,9 +7914,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
-      "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
       "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
@@ -7928,6 +7928,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -21246,15 +21249,18 @@
       "dev": true
     },
     "node_modules/tsutils": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.20.0.tgz",
-      "integrity": "sha512-RYbuQuvkhuqVeXweWT3tJLKOEJ/UUw9GjNEZGWdrLLlM+611o1gwLHBpxoFJKKl25fLprp2eVthtKs5JOrNeXg==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
       "dependencies": {
         "tslib": "^1.8.1"
       },
       "engines": {
         "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
     "node_modules/tty-browserify": {
@@ -28676,9 +28682,9 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
-      "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
@@ -38918,9 +38924,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.20.0.tgz",
-      "integrity": "sha512-RYbuQuvkhuqVeXweWT3tJLKOEJ/UUw9GjNEZGWdrLLlM+611o1gwLHBpxoFJKKl25fLprp2eVthtKs5JOrNeXg==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "eslint-plugin-react": "7.24.0",
         "eslint-plugin-react-hooks": "4.2.0",
         "jest": "27.0.1",
-        "next": "10.2.3",
+        "next": "^11.0.0",
         "prettier": "2.3.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",
@@ -44,7 +44,7 @@
         "typescript": "4.3.2"
       },
       "peerDependencies": {
-        "next": "^9 || ^10"
+        "next": "^9 || ^10 || ^11"
       }
     },
     "node_modules/@babel/cli": {
@@ -2810,21 +2810,21 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-10.2.3.tgz",
-      "integrity": "sha512-uBOjRBjsWC4C8X3DfmWWP6ekwLnf2JCCwQX9KVnJtJkqfDsv1yQPakdOEwvJzXQc3JC/v5KKffYPVmV2wHXCgQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.0.0.tgz",
+      "integrity": "sha512-VKpmDvTYeCpEQjREg3J4pCmVs/QjEzoLmkM8shGFK6e9AmFd0G9QXOL8HGA8qKhy/XmNb7dHeMqrcMiBua4OgA==",
       "dev": true
     },
     "node_modules/@next/polyfill-module": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-10.2.3.tgz",
-      "integrity": "sha512-OkeY4cLhzfYbXxM4fd+6V4s5pTPuyfKSlavItfNRA6PpS7t1/R6YjO7S7rB8tu1pbTGuDHGIdE1ioDv15bAbDQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.0.0.tgz",
+      "integrity": "sha512-gydtFzRqsT549U8+sY8382I/f4HFcelD8gdUGnAofQJa/jEU1jkxmjCHC8tmEiyeMLidl7iDZgchfSCpmMzzUg==",
       "dev": true
     },
     "node_modules/@next/react-dev-overlay": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-10.2.3.tgz",
-      "integrity": "sha512-E6g2jws4YW94l0lMMopBVKIZK2mEHfSBvM0d9dmzKG9L/A/kEq6LZCB4SiwGJbNsAdlk2y3USDa0oNbpA+m5Kw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.0.0.tgz",
+      "integrity": "sha512-q+Wp+eStEMThe77zxdeJ/nbuODkHR6P+/dfUqYXZSqbLf6x5c5xwLBauwwVbkCYFZpAlDuL8Jk8QSAH1OsqC2w==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
@@ -2840,8 +2840,8 @@
         "strip-ansi": "6.0.0"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17",
-        "react-dom": "^16.9.0 || ^17"
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
       }
     },
     "node_modules/@next/react-dev-overlay/node_modules/ansi-styles": {
@@ -2927,9 +2927,9 @@
       }
     },
     "node_modules/@next/react-refresh-utils": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-10.2.3.tgz",
-      "integrity": "sha512-qtBF56vPC6d6a8p7LYd0iRjW89fhY80kAIzmj+VonvIGjK/nymBjcFUhbKiMFqlhsarCksnhwX+Zmn95Dw9qvA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.0.0.tgz",
+      "integrity": "sha512-hi5eY+KBn4QGtUv7VL2OptdM33fI2hxhd7+omOFmAK+S0hDWhg1uqHqqGJk0W1IfqlWEzzL10WvTJDPRAtDugQ==",
       "dev": true,
       "peerDependencies": {
         "react-refresh": "0.8.3",
@@ -3357,27 +3357,6 @@
       "dependencies": {
         "@octokit/openapi-types": "^3.2.1",
         "@types/node": ">= 8"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.14.0.tgz",
-      "integrity": "sha512-L7RMuZr5LzMmZiQSQDy9O1jo0q+DaLy6XpYJfIGfYSfoJA5qzYwUP3sP1uMIQ549DvxAgM3ng85EaPTM/hUHwQ==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/context-base": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/context-base": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.14.0.tgz",
-      "integrity": "sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
@@ -8246,6 +8225,21 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.0.tgz",
+      "integrity": "sha512-JLJ6OwBfO1KcA+TvJT+v8gbE6iWbj24LyDNFgFEN0lzegn6cC6a/p3NIDaepMsJjQjlUWqIC7wJv8lBFxPNjcw==",
+      "dev": true,
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/import-fresh": {
@@ -13168,18 +13162,17 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-10.2.3.tgz",
-      "integrity": "sha512-dkM1mIfnORtGyzw/Yme8RdqNxlCMZyi4Lqj56F01/yHbe1ZtOaJ0cyqqRB4RGiPhjGGh0319f8ddjDyO1605Ow==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-11.0.0.tgz",
+      "integrity": "sha512-1OA0ccCTwVtdLats/1v7ReiBVx+Akya0UVhHo9IBr8ZkpDI3/SGNcaruJBp5agy8ROF97VDKkZamoUXxRB9NUA==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "7.12.5",
         "@hapi/accept": "5.0.2",
-        "@next/env": "10.2.3",
-        "@next/polyfill-module": "10.2.3",
-        "@next/react-dev-overlay": "10.2.3",
-        "@next/react-refresh-utils": "10.2.3",
-        "@opentelemetry/api": "0.14.0",
+        "@next/env": "11.0.0",
+        "@next/polyfill-module": "11.0.0",
+        "@next/react-dev-overlay": "11.0.0",
+        "@next/react-refresh-utils": "11.0.0",
         "assert": "2.0.0",
         "ast-types": "0.13.2",
         "browserify-zlib": "0.2.0",
@@ -13197,6 +13190,7 @@
         "find-cache-dir": "3.3.1",
         "get-orientation": "1.1.2",
         "https-browserify": "1.0.0",
+        "image-size": "1.0.0",
         "jest-worker": "27.0.0-next.5",
         "native-url": "0.3.4",
         "node-fetch": "2.6.1",
@@ -13211,7 +13205,7 @@
         "prop-types": "15.7.2",
         "querystring-es3": "0.2.1",
         "raw-body": "2.4.1",
-        "react-is": "16.13.1",
+        "react-is": "17.0.2",
         "react-refresh": "0.8.3",
         "stream-browserify": "3.0.0",
         "stream-http": "3.1.1",
@@ -13228,13 +13222,13 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=12.0.0"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
         "node-sass": "^4.0.0 || ^5.0.0",
-        "react": "^16.6.0 || ^17",
-        "react-dom": "^16.6.0 || ^17",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
@@ -13318,6 +13312,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/next/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
     },
     "node_modules/next/node_modules/stream-http": {
       "version": "3.1.1",
@@ -19254,6 +19254,15 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "~2.0.3"
+      }
+    },
     "node_modules/quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -24434,21 +24443,21 @@
       }
     },
     "@next/env": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-10.2.3.tgz",
-      "integrity": "sha512-uBOjRBjsWC4C8X3DfmWWP6ekwLnf2JCCwQX9KVnJtJkqfDsv1yQPakdOEwvJzXQc3JC/v5KKffYPVmV2wHXCgQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.0.0.tgz",
+      "integrity": "sha512-VKpmDvTYeCpEQjREg3J4pCmVs/QjEzoLmkM8shGFK6e9AmFd0G9QXOL8HGA8qKhy/XmNb7dHeMqrcMiBua4OgA==",
       "dev": true
     },
     "@next/polyfill-module": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-10.2.3.tgz",
-      "integrity": "sha512-OkeY4cLhzfYbXxM4fd+6V4s5pTPuyfKSlavItfNRA6PpS7t1/R6YjO7S7rB8tu1pbTGuDHGIdE1ioDv15bAbDQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.0.0.tgz",
+      "integrity": "sha512-gydtFzRqsT549U8+sY8382I/f4HFcelD8gdUGnAofQJa/jEU1jkxmjCHC8tmEiyeMLidl7iDZgchfSCpmMzzUg==",
       "dev": true
     },
     "@next/react-dev-overlay": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-10.2.3.tgz",
-      "integrity": "sha512-E6g2jws4YW94l0lMMopBVKIZK2mEHfSBvM0d9dmzKG9L/A/kEq6LZCB4SiwGJbNsAdlk2y3USDa0oNbpA+m5Kw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.0.0.tgz",
+      "integrity": "sha512-q+Wp+eStEMThe77zxdeJ/nbuODkHR6P+/dfUqYXZSqbLf6x5c5xwLBauwwVbkCYFZpAlDuL8Jk8QSAH1OsqC2w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -24525,9 +24534,9 @@
       }
     },
     "@next/react-refresh-utils": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-10.2.3.tgz",
-      "integrity": "sha512-qtBF56vPC6d6a8p7LYd0iRjW89fhY80kAIzmj+VonvIGjK/nymBjcFUhbKiMFqlhsarCksnhwX+Zmn95Dw9qvA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.0.0.tgz",
+      "integrity": "sha512-hi5eY+KBn4QGtUv7VL2OptdM33fI2hxhd7+omOFmAK+S0hDWhg1uqHqqGJk0W1IfqlWEzzL10WvTJDPRAtDugQ==",
       "dev": true,
       "requires": {}
     },
@@ -24907,21 +24916,6 @@
         "@octokit/openapi-types": "^3.2.1",
         "@types/node": ">= 8"
       }
-    },
-    "@opentelemetry/api": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.14.0.tgz",
-      "integrity": "sha512-L7RMuZr5LzMmZiQSQDy9O1jo0q+DaLy6XpYJfIGfYSfoJA5qzYwUP3sP1uMIQ549DvxAgM3ng85EaPTM/hUHwQ==",
-      "dev": true,
-      "requires": {
-        "@opentelemetry/context-base": "^0.14.0"
-      }
-    },
-    "@opentelemetry/context-base": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.14.0.tgz",
-      "integrity": "sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw==",
-      "dev": true
     },
     "@semantic-release/commit-analyzer": {
       "version": "8.0.1",
@@ -28942,6 +28936,15 @@
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
       "dev": true
     },
+    "image-size": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.0.tgz",
+      "integrity": "sha512-JLJ6OwBfO1KcA+TvJT+v8gbE6iWbj24LyDNFgFEN0lzegn6cC6a/p3NIDaepMsJjQjlUWqIC7wJv8lBFxPNjcw==",
+      "dev": true,
+      "requires": {
+        "queue": "6.0.2"
+      }
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -32747,18 +32750,17 @@
       "dev": true
     },
     "next": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-10.2.3.tgz",
-      "integrity": "sha512-dkM1mIfnORtGyzw/Yme8RdqNxlCMZyi4Lqj56F01/yHbe1ZtOaJ0cyqqRB4RGiPhjGGh0319f8ddjDyO1605Ow==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-11.0.0.tgz",
+      "integrity": "sha512-1OA0ccCTwVtdLats/1v7ReiBVx+Akya0UVhHo9IBr8ZkpDI3/SGNcaruJBp5agy8ROF97VDKkZamoUXxRB9NUA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "7.12.5",
         "@hapi/accept": "5.0.2",
-        "@next/env": "10.2.3",
-        "@next/polyfill-module": "10.2.3",
-        "@next/react-dev-overlay": "10.2.3",
-        "@next/react-refresh-utils": "10.2.3",
-        "@opentelemetry/api": "0.14.0",
+        "@next/env": "11.0.0",
+        "@next/polyfill-module": "11.0.0",
+        "@next/react-dev-overlay": "11.0.0",
+        "@next/react-refresh-utils": "11.0.0",
         "assert": "2.0.0",
         "ast-types": "0.13.2",
         "browserify-zlib": "0.2.0",
@@ -32776,6 +32778,7 @@
         "find-cache-dir": "3.3.1",
         "get-orientation": "1.1.2",
         "https-browserify": "1.0.0",
+        "image-size": "1.0.0",
         "jest-worker": "27.0.0-next.5",
         "native-url": "0.3.4",
         "node-fetch": "2.6.1",
@@ -32790,7 +32793,7 @@
         "prop-types": "15.7.2",
         "querystring-es3": "0.2.1",
         "raw-body": "2.4.1",
-        "react-is": "16.13.1",
+        "react-is": "17.0.2",
         "react-refresh": "0.8.3",
         "stream-browserify": "3.0.0",
         "stream-http": "3.1.1",
@@ -32853,6 +32856,12 @@
           "requires": {
             "yocto-queue": "^0.1.0"
           }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
         },
         "stream-http": {
           "version": "3.1.1",
@@ -37261,6 +37270,15 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
+    },
+    "queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.3"
+      }
     },
     "quick-lru": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-react": "7.24.0",
     "eslint-plugin-react-hooks": "4.2.0",
     "jest": "27.0.1",
-    "next": "10.2.3",
+    "next": "^11.0.0",
     "prettier": "2.3.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "typescript": "4.3.2"
   },
   "peerDependencies": {
-    "next": "^9 || ^10"
+    "next": "^9 || ^10 || ^11"
   }
 }


### PR DESCRIPTION
The plugin works correctly on Next v11.0.0, so it should be added to the allowed next versions in peerDependencies.
Test repo: https://github.com/sachinraja/next-plugin-preval-next-11