### PR TITLE
fix: bump babel target to 12

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["@babel/preset-env", { "targets": "node 10 and not IE 11" }],
+    ["@babel/preset-env", { "targets": "node 12 and not IE 11" }],
     "@babel/preset-typescript"
   ]
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -76,7 +76,7 @@ export async function _prevalLoader(
     ] as const);
 
   register({
-    presets: ['next/babel', ['@babel/preset-env', { targets: 'node 10' }]],
+    presets: ['next/babel', ['@babel/preset-env', { targets: 'node 12' }]],
     plugins: [
       // conditionally add
       ...(moduleResolver ? [moduleResolver] : []),


### PR DESCRIPTION
Tries to bump the preset-env target of babel to `node 12` in an attempt to fix #66.